### PR TITLE
Drop _use_proxy from plugin

### DIFF
--- a/parts/plugins/x-jenkins.py
+++ b/parts/plugins/x-jenkins.py
@@ -25,10 +25,6 @@ class JenkinsPlugin(snapcraft.plugins.maven.MavenPlugin):
         super().__init__(name, options, project)
         self.build_packages.append('maven')
 
-    def _use_proxy(self):
-        return all([k in os.environ for k in
-                    ('SNAPCRAFT_LOCAL_SOURCES', 'http_proxy')])
-
     def env(self, root):
         # Jenkins wants fonts and git.
         env = ['XDG_DATA_HOME=%s/usr/share' % root,


### PR DESCRIPTION
The one defined in snapcraft's maven plugin is more correct: this
version never returns true for a Launchpad build because
SNAPCRAFT_LOCAL_SOURCES is only defined in the pull phase; and there's
no reason to diverge from the maven plugin on this anyway.